### PR TITLE
fix: flip camera

### DIFF
--- a/src/solvrocam/detection.py
+++ b/src/solvrocam/detection.py
@@ -16,6 +16,7 @@ try:
     from picamera2 import Picamera2  # pyright: ignore[reportMissingImports]
     from picamera2.encoders import H264Encoder  # pyright: ignore[reportMissingImports]
     from picamera2.outputs import PyavOutput  # pyright: ignore[reportMissingImports]
+    from libcamera import Transform  # pyright: ignore[reportMissingImports]
 except ModuleNotFoundError:
     pass
 from requests import Request, Response, Session
@@ -85,6 +86,7 @@ class Solvrocam:
             main={"size": main_size, "format": main_format},
             lores={"size": lores_size, "format": lores_format},
             display=None,
+            transform=Transform(hflip=True, vflip=True),
             encode="lores",
             buffer_count=5,
             controls={"FrameRate": framerate},


### PR DESCRIPTION
Flip camera because sensor has to be mounted upside down now that we are on rPi 5

before:
<img width="510" height="435" alt="Screenshot_06-Sep_14-07-18_7885" src="https://github.com/user-attachments/assets/10b53a6e-be9d-4cef-8a9d-4710a1406230" />

after:
<img width="1921" height="1044" alt="Screenshot_06-Sep_13-53-43_26793" src="https://github.com/user-attachments/assets/aae7fa26-a42c-42cf-9624-a9016859e2cf" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds camera flip transformation in `start_camera()` in `detection.py` for rPi 5 compatibility.
> 
>   - **Behavior**:
>     - Adds `transform=Transform(hflip=True, vflip=True)` to `start_camera()` in `detection.py` to flip the camera image horizontally and vertically.
>   - **Imports**:
>     - Adds `Transform` import from `libcamera` in `detection.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fhardware-solvro-bot-office-cam&utm_source=github&utm_medium=referral)<sup> for e9e5c29a6f8119972a20e7c309881fa49e4fa05c. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->